### PR TITLE
fix: use the field for the user message from missive webhooks

### DIFF
--- a/api.js
+++ b/api.js
@@ -120,7 +120,7 @@ async function listMessages(emailMessageId) {
   return data.messages;
 }
 function processWebhookPayload(payload) {
-  const userMessage = payload.userMessage;
+  const userMessage = payload.comment.body
   const userName = payload.userName;
   const userEmail = payload.userEmail;
   const conversationId = payload.conversationId;


### PR DESCRIPTION
Looks like this PR references the user message in a way that does not exist in my testing, this fixes it to correctly use the correct field from the webhook payload - there are likely other parts of the payload not being parsed properly as well

PR responsible: https://github.com/room302studio/coachartie/commit/f20583a27016e6acb652a32a4a46f38c2b0e4936

<img width="494" alt="Screenshot 2024-03-28 at 2 58 13 PM" src="https://github.com/room302studio/coachartie/assets/530073/4a6bf2a9-e57c-4a8a-8bee-f840602e3ba6">

<img width="375" alt="Screenshot 2024-03-28 at 2 58 23 PM" src="https://github.com/room302studio/coachartie/assets/530073/54ce690d-d063-46cb-8b1a-1e4b96bb7290">

cc @rajivsinclair
